### PR TITLE
Fix messages getting lost.

### DIFF
--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -26,6 +26,8 @@ namespace AWS.Logger.Core
         const int MAX_MESSAGE_SIZE_IN_BYTES = 256000;
 
         #region Private Members
+        private static readonly DateTime MIN_TIMESTAMP_UTC_KIND = new DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
         const string EMPTY_MESSAGE = "\t";
         private ConcurrentQueue<InputLogEvent> _pendingMessageQueue = new ConcurrentQueue<InputLogEvent>();
         private string _currentStreamName = null;
@@ -35,9 +37,17 @@ namespace AWS.Logger.Core
         private ManualResetEventSlim _flushCompletedEvent;
         private AWSLoggerConfig _config;
         private IAmazonCloudWatchLogs _client;
-        private DateTime _maxBufferTimeStamp = new DateTime();
+
+        /// <summary>
+        /// Last time an error message was registered due to overflowing in-memory buffer.
+        /// </summary>
+        private DateTime _maxBufferTimeStamp = MIN_TIMESTAMP_UTC_KIND;
         private string _logType;
         private int _requestCount = 5;
+
+        /// <summary>
+        /// Minimum interval in minutes between two error messages on in-memory buffer overflow.
+        /// </summary>
         const double MAX_BUFFER_TIMEDIFF = 5;
         private readonly static Regex invalid_sequence_token_regex = new
             Regex(@"The given sequenceToken is invalid. The next expected sequenceToken is: (\d+)");
@@ -242,27 +252,25 @@ namespace AWS.Logger.Core
             {
                 if (_maxBufferTimeStamp.AddMinutes(MAX_BUFFER_TIMEDIFF) < DateTime.UtcNow)
                 {
-                    message = "The AWS Logger in-memory buffer has reached maximum capacity";
-                    if (_maxBufferTimeStamp == DateTime.MinValue)
+                    if (_maxBufferTimeStamp == MIN_TIMESTAMP_UTC_KIND)
                     {
+                        string errorMessage = $"The AWS Logger in-memory buffer has reached maximum capacity of {_config.MaxQueuedMessages:N0} entries. Currently contains {_pendingMessageQueue.Count:N0} entries.";
                         LogLibraryServiceError(new System.InvalidOperationException(message));
+                        _pendingMessageQueue.Enqueue(new InputLogEvent
+                        {
+                            Timestamp = timestampNn,
+                            Message = errorMessage
+                        });
                     }
                     _maxBufferTimeStamp = DateTime.UtcNow;
-                    _pendingMessageQueue.Enqueue(new InputLogEvent
-                    {
-                        Timestamp = timestampNn,
-                        Message = message,
-                    });
                 }
             }
-            else
+
+            _pendingMessageQueue.Enqueue(new InputLogEvent
             {
-                _pendingMessageQueue.Enqueue(new InputLogEvent
-                {
-                    Timestamp = timestampNn,
-                    Message = message,
-                });
-            }
+                Timestamp = timestampNn,
+                Message = message,
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
The logic of AddSingleMessage is unclear from the logic itself. In the previous version, the contents of the message would be replaced always be an error when the queue size is exceeded and the new text was being logged once every five minutes. In all other cases, no message was logged. In all cases, the original cases would be lost without displaying the amount lost.

The reason why messages are not being processed remains to be studied. It occurs despite sufficient sizing and several times a day in a large SAAS-environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
